### PR TITLE
update 2.7 package version

### DIFF
--- a/version/2_7.sh
+++ b/version/2_7.sh
@@ -2,10 +2,10 @@
 
 echo "================= Installing Python 2.7.12 ==================="
 sudo apt-get install -y \
-  python2.7=2.7.12-1ubuntu0~16.04.2 \
-  python-dev=2.7.11-1 \
-  python-pip=8.1.1-2ubuntu0.4 \
-  python-virtualenv=15.0.1+ds-3ubuntu1
+  python2.7=2.7.12* \
+  python-dev=2.7.11* \
+  python-pip=8.1.1* \
+  python-virtualenv=15.0.1*
 
 # Install virtualenv
 virtualenv -p python $HOME/venv/2.7


### PR DESCRIPTION
fix breaking build by only locking till minor version
https://app.shippable.com/github/Shippable/jobs/pyt_aarch_64_Ubuntu_16_04_prep/builds/5a6757552e5dfd07006188a0/console

keep using default python 2.7 from official ubuntu repo.